### PR TITLE
fixed dependency on hg19 chromosome sizes

### DIFF
--- a/cooler_ontad.py
+++ b/cooler_ontad.py
@@ -9,12 +9,9 @@ import warnings
 import numpy as np
 import pandas as pd
 import cooler
-import bioframe
 import click
 
 # get chromosomal arms
-
-chromsizes = bioframe.fetch_chromsizes("hg19")
 
 
 def convert_to_bedpe(
@@ -120,7 +117,7 @@ def create_dense_matrix(filep, binsize):
     filename = os.path.basename(filep)
     filename_base = filename[:-6]
     temp_folder = tempfile.mkdtemp(suffix=None, prefix=None, dir=None)
-    for chr_name in chromsizes.index:
+    for chr_name in cooler_obj.chromsizes.index:
         matrix = cooler_obj.matrix(balance=True).fetch(chr_name)
         matrix = np.nan_to_num(matrix)
         # print(chr_name)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name="cooler_ontad",
     version="0.1",
     py_modules=["cooler_ontad"],
-    install_requires=["click", "bioframe", "cooler", "numpy", "pandas",],
+    install_requires=["click", "cooler", "numpy", "pandas",],
     entry_points="""
         [console_scripts]
         cooler_ontad=cooler_ontad:main


### PR DESCRIPTION
I realized that the current version of `cooler_ontad` has hard-coded chromosome sizes from hg19 and fixed that by taking the chromosome sizes stored in the cooler file on which `cooler_ontad` is operating. This also removes the dependency on `bioframe`.